### PR TITLE
Bugfix: Outdated dependencies and problems running #34

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -2,6 +2,7 @@ var Path = nodeRequire('path');
 var $ = require('jquery');
 var _ = require('underscore');
 var menubar = new gui.Menu({ type: 'menubar' });
+menubar.createMacBuiltin("p5");
 var fileMenu = new gui.Menu();
 var help = new gui.Menu();
 var win = gui.Window.get();
@@ -55,7 +56,7 @@ module.exports.setup = function(app) {
   }}));
 
   win.menu = menubar;
-  win.menu.insert(new gui.MenuItem({ label: 'File', submenu: fileMenu}), 1);
+  win.menu.insert(new gui.MenuItem({ label: 'File', submenu: fileMenu}),1);
   win.menu.append(new gui.MenuItem({ label: 'Help', submenu: help}));
 
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "gulp-rename": "^1.2.0",
     "partialify": "^3.1.1",
     "gulp": "^3.5.6",
-    "nodewebkit": "0.9.2",
+    "nw": "0.12.0",
     "browserify": "^3.33.1",
     "vue": "^0.10.3",
     "gulp-sass": "^0.7.1",
@@ -26,7 +26,7 @@
     "gulp-download": "0.0.1"
   },
   "scripts": {
-    "app": "nodewebkit public"
+    "app": "nw public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Nodewebkit was renamed to nw, so I updated the dependency. The edit menu is now only shown on a native mac menubar, so the error mentioned in #34 appear. I used the native menubar to fix it