### PR TITLE
fixed so that console is cleared on run

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -376,6 +376,7 @@ var appConfig = {
       if (this.running) {
         this.modeFunction('stop');
       } else {
+        $('#debug').html('');
         this.modeFunction('run');
       }
     },


### PR DESCRIPTION
added code to clear debug window in toggleRun method. Previously debug window was only cleared in the run method. As a side note, it's not clear that the run method is ever called.. possibly it can be removed?