### PR TITLE
Default widow size adjust

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -169,7 +169,7 @@ var appConfig = {
         x: currentWindow.x + 50,
         y: currentWindow.y + 50,
         width: 1024,
-        height: 768,
+        height: 700,
         toolbar: false,
         focus: true,
         show: false

--- a/public/package.json
+++ b/public/package.json
@@ -8,7 +8,7 @@
     "frame": true,
     "position": "center",
     "width": 1024,
-    "height": 768,
+    "height": 700,
     "show": false,
     "focus": true,
     "resizable": true


### PR DESCRIPTION
The previous default size was too large for smaller displays, so I made a temporary fix. We should look into choosing specific dimensions we know will work reliably.