### PR TITLE
Fixed Multi-project saving issue

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -41,7 +41,9 @@ var appConfig = {
     running: false,
     settings: {},
     showSettings: false,
-    files: []
+    files: [],
+    justSaved: false,
+    //saveTarget: window 
   },
 
   computed: {
@@ -146,6 +148,13 @@ var appConfig = {
           win = null;
         }
       });
+      win.on('focus', function(){
+        // console.log("window focus: " + self.currentFile.path);
+        // console.log("window path: " + win.window.PATH);
+        // self.saveTarget = self.currentFile;
+        //menu.setup(self);
+        menu.resetMenu();
+      });
     },
 
     // todo: setup drag and drop
@@ -230,6 +239,14 @@ var appConfig = {
         Files.removeFromTree(path, self.files);
       }).on('unlinkDir', function(path) {
         Files.removeFromTree(path, self.files);
+      }).on('change', function(path) {
+        //console.log(String(self.justSaved));
+        if (self.justSaved) {
+          self.justSaved = false; 
+          //console.log("File " + path + " changed internally");
+        } else {
+          console.log("File " + path + " changed externally");
+        }
       })
     },
 
@@ -294,8 +311,18 @@ var appConfig = {
     },
 
     writeFile: function() {
+      var win = gui.Window.get()
+      var self = this;
+
+      console.log("currentFile: " + this.currentFile.path + "window.PATH: " + 
+                  win.window.PATH + "saveTarget: " + this.saveTarget.path);
+      self.justSaved = true;
+      self.currentFile = Files.find(self.files, win.window.PATH);
+
       fs.writeFileSync(this.currentFile.path, this.currentFile.contents, "utf8");
       this.currentFile.originalContents = this.currentFile.contents;
+      console.log("change made to " + this.currentFile.path);
+
     },
 
     // open up a file - read its contents if it's not already opened

--- a/app/main.js
+++ b/app/main.js
@@ -314,14 +314,14 @@ var appConfig = {
       var win = gui.Window.get()
       var self = this;
 
-      console.log("currentFile: " + this.currentFile.path + "window.PATH: " + 
-                  win.window.PATH + "saveTarget: " + this.saveTarget.path);
+      //console.log("currentFile: " + this.currentFile.path + "window.PATH: " + 
+      //            win.window.PATH + "saveTarget: " + this.saveTarget.path);
       self.justSaved = true;
       self.currentFile = Files.find(self.files, win.window.PATH);
 
       fs.writeFileSync(this.currentFile.path, this.currentFile.contents, "utf8");
       this.currentFile.originalContents = this.currentFile.contents;
-      console.log("change made to " + this.currentFile.path);
+      //console.log("change made to " + this.currentFile.path);
 
     },
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -32,7 +32,7 @@ module.exports.setup = function(app) {
   }}));
 
   fileMenu.append(new gui.MenuItem({ label: 'Save', modifiers: 'cmd', key: 's', click: function(){
-    console.log(app);
+    //console.log(app);
     app.saveFile();
   }}));
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -9,6 +9,7 @@ var win = gui.Window.get();
 var recentFilesMenu = new gui.Menu();
 var openRecent;
 
+
 module.exports.setup = function(app) {
   fileMenu.append(new gui.MenuItem({ label: 'New File', modifiers: 'cmd', key: 'n', click: function(){
     app.newFile();
@@ -31,6 +32,7 @@ module.exports.setup = function(app) {
   }}));
 
   fileMenu.append(new gui.MenuItem({ label: 'Save', modifiers: 'cmd', key: 's', click: function(){
+    console.log(app);
     app.saveFile();
   }}));
 
@@ -57,11 +59,15 @@ module.exports.setup = function(app) {
     app.showHelp();
   }}));
 
+  menubar.insert(new gui.MenuItem({ label: 'File', submenu: fileMenu}),1);
+  menubar.append(new gui.MenuItem({ label: 'Help', submenu: help}));
   win.menu = menubar;
-  win.menu.insert(new gui.MenuItem({ label: 'File', submenu: fileMenu}),1);
-  win.menu.append(new gui.MenuItem({ label: 'Help', submenu: help}));
 
 };
+
+module.exports.resetMenu = function() {
+  win.menu = menubar;
+}
 
 module.exports.updateRecentFiles = function(app, path) {
   var recentFiles = JSON.parse(localStorage.recentFiles || '[]');


### PR DESCRIPTION
Taking out some of the mousetrap dependencies caused an issue where the most recently opened project would be the one saved regardless of in which project Save was pushed. Resolved.