### PR TITLE
changed all references of lmccart/p5.js github repo to processing/p5.js

### DIFF
--- a/app/modes/p5/p5-mode.js
+++ b/app/modes/p5/p5-mode.js
@@ -91,7 +91,7 @@ module.exports = {
 
   update: function(callback) {
     var pathPrefix = 'mode_assets/p5/empty_project/libraries/';
-    var urlPrefex = 'https://raw.githubusercontent.com/lmccart/p5.js/master/lib/';
+    var urlPrefex = 'https://raw.githubusercontent.com/processing/p5.js/master/lib/';
 
     var files = [
       { local: pathPrefix + 'p5.js', remote: urlPrefex + 'p5.js' },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,9 +110,9 @@ function latest () {
 
 gulp.task('p5', function () {
   var urls = [
-    'https://raw.githubusercontent.com/lmccart/p5.js/master/lib/p5.js',
-    'https://raw.githubusercontent.com/lmccart/p5.js/master/lib/addons/p5.sound.js',
-    'https://raw.githubusercontent.com/lmccart/p5.js/master/lib/addons/p5.dom.js',
+    'https://raw.githubusercontent.com/processing/p5.js/master/lib/p5.js',
+    'https://raw.githubusercontent.com/processing/p5.js/master/lib/addons/p5.sound.js',
+    'https://raw.githubusercontent.com/processing/p5.js/master/lib/addons/p5.dom.js',
   ];
 
   urls.forEach(function(url) {

--- a/public/mode_assets/p5/empty_project/libraries/p5.dom.js
+++ b/public/mode_assets/p5/empty_project/libraries/p5.dom.js
@@ -14,7 +14,7 @@
  * <a href="http://p5js.org/libraries/#using-a-library">using a library</a>
  * section for information on how to include this library. p5.dom comes with
  * <a href="http://p5js.org/download">p5 complete</a> or you can download the single file
- * <a href="https://raw.githubusercontent.com/lmccart/p5.js/master/lib/addons/p5.dom.js">
+ * <a href="https://raw.githubusercontent.com/processing/p5.js/master/lib/addons/p5.dom.js">
  * here</a>.</p>
  * <p>See <a href="https://github.com/processing/p5.js/wiki/Beyond-the-canvas">tutorial: beyond the canvas]</a>
  * for more info on how to use this libary.</a>


### PR DESCRIPTION
The urls were kindly forwarded by github to the new repo but why depend on github's courtesy when there is such a thing as find/replace. 