### PR TITLE
automatic new screen resizing & reload message edit

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -110,6 +110,9 @@ var appConfig = {
     }
     var win = gui.Window.get();
     win.setMinimumSize(400,400);
+    if(($(window).width() + 100 >= screen.width) || ($(window).height() + 100 >= screen.height)){
+      win.resizeTo((screen.width * 4)/5,(screen.height * 7)/8);
+    }
   },
 
   methods: {
@@ -174,7 +177,7 @@ var appConfig = {
         self.resetMenu();
         if (self.askReload) {
           self.askReload = false;
-          var shouldRefresh = confirm(self.currentFile.path + ' was edited somewhere else. Reload? You will lose any changes.');
+          var shouldRefresh = confirm(self.currentFile.path + ' was edited on the disk. Reload? You will lose any changes.');
           if (shouldRefresh) {
               //self.openProject(self.currentFile.path);
               //gui.Window.get().close(true);
@@ -209,7 +212,7 @@ var appConfig = {
         x: currentWindow.x + 50,
         y: currentWindow.y + 50,
         width: 1024,
-        height: 700,
+        height: 768,
         toolbar: false,
         focus: true,
         show: false

--- a/public/package.json
+++ b/public/package.json
@@ -8,7 +8,7 @@
     "frame": true,
     "position": "center",
     "width": 1024,
-    "height": 700,
+    "height": 768,
     "show": false,
     "focus": true,
     "resizable": true


### PR DESCRIPTION
if the editor's default size is too large for the screen, it will now resize automatically. I also made a small edit to the message that the user receives when an open file is edited elsewhere. I'll probably change it again later.