### PR TITLE
added menu items for existing shortcuts & setting controls

### DIFF
--- a/app/keybindings.js
+++ b/app/keybindings.js
@@ -38,21 +38,21 @@ module.exports.setup = function(app) {
     gui.Window.get().showDevTools();
   });
 
-  Mousetrap.bind(['command+=', 'ctrl+='], function(e) {
+  /*Mousetrap.bind(['command+=', 'ctrl+='], function(e) {
     app.changeFontSize(1);
   });
 
   Mousetrap.bind(['command+-', 'ctrl+-'], function(e) {
     app.changeFontSize(-1);
-  });
+  });*/
 
-  Mousetrap.bind(['command+t', 'ctrl+t'], function(e) {
+  /*Mousetrap.bind(['command+t', 'ctrl+t'], function(e) {
     app.$.editor.reformat();
-  });
+  });*/
 
-  Mousetrap.bind(['command+,', 'ctrl+,'], function(e) {
+  /*Mousetrap.bind(['command+,', 'ctrl+,'], function(e) {
     app.toggleSettingsPane();
-  });
+  });*/
 
   Mousetrap.stopCallback = function(e, element, combo) {
     return false;

--- a/app/main.js
+++ b/app/main.js
@@ -528,6 +528,10 @@ var appConfig = {
       this.showSettings = !this.showSettings;
     },
 
+    toggleSidebar: function() {
+      this.settings.showSidebar = !this.settings.showSidebar;
+    },
+
     showHelp: function() {
       gui.Shell.openExternal(this.$options.mode.referenceURL);
     }

--- a/app/menu.js
+++ b/app/menu.js
@@ -7,6 +7,8 @@ var menubar = new gui.Menu({ type: 'menubar' });
 menubar.createMacBuiltin("p5");
 var fileMenu = new gui.Menu();
 var help = new gui.Menu();
+//var edit = new gui.Menu();
+var view = new gui.Menu();
 var win = gui.Window.get();
 var recentFilesMenu = new gui.Menu();
 var exampleCategoryMenu = new gui.Menu();
@@ -92,7 +94,33 @@ module.exports.setup = function(app) {
     app.showHelp();
   }}));
 
+  view.append(new gui.MenuItem({ label: 'Reformat', modifiers: 'cmd', key: 't', click: function(){
+    app.$.editor.reformat();
+  }}));
+
+  view.append(new gui.MenuItem({ type: 'separator' }));
+
+  view.append(new gui.MenuItem({ label: 'Toggle Settings Panel', modifiers: 'cmd', key: ',', click: function(){
+    app.toggleSettingsPane();
+  }}))
+
+  view.append(new gui.MenuItem({ label: 'Toggle Sidebar', modifiers: 'cmd', key: '.', click: function(){
+    app.toggleSidebar();
+  }}))
+
+  view.append(new gui.MenuItem({ type: 'separator' }));
+
+  view.append(new gui.MenuItem({ label: 'Increase Font Size', modifiers: 'cmd', key: '=', click: function(){
+    app.changeFontSize(1);
+  }}))
+
+  view.append(new gui.MenuItem({ label: 'Decrease Font Size', modifiers: 'cmd', key: '-', click: function(){
+    app.changeFontSize(-1);
+  }}))
+
   menubar.insert(new gui.MenuItem({ label: 'File', submenu: fileMenu}),1);
+  //menubar.insert(new gui.MenuItem({ label: 'Edit', submenu: edit}), 2);
+  menubar.insert(new gui.MenuItem({ label: 'View', submenu: view}), 3);
   menubar.append(new gui.MenuItem({ label: 'Help', submenu: help}));
   win.menu = menubar;
 


### PR DESCRIPTION
Many of the functions which only had shortcut commands (reformat, inc/dec font size, etc) have been menu items from which they can also be called. The control for hide/show sidebar was previously limited to the settings window. It now has a menu item and a shortcut ('cmd' + '.').