### PR TITLE
[windows] re-running properly focuses window

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -214,6 +214,7 @@ module.exports.setup = function(app) {
     fileMenu.append(new gui.MenuItem({ label: 'Run',
       modifiers: 'cmd', key: 'r', click: function(){
         app.run();
+        
     }}));
 
     view.append(new gui.MenuItem({ label: 'Show Sketch Folder',

--- a/app/modes/p5/p5-mode.js
+++ b/app/modes/p5/p5-mode.js
@@ -95,6 +95,10 @@ module.exports = {
         gui.Shell.openExternal(url);
       } else {
         this.outputWindow.reloadIgnoringCache();
+        if(isWin){
+          self.outputWindow.hide();
+          self.outputWindow.show();
+        }
       }
     } else {
       // gui.App.clearCache();


### PR DESCRIPTION
running an app, unfocusing the output window, and hitting Run would previously not re-focus the output window. Now resolved.