### PR TITLE
fix bug #79

### DIFF
--- a/app/sidebar/index.js
+++ b/app/sidebar/index.js
@@ -97,7 +97,9 @@ module.exports = {
       folder.open = !folder.open;
       if (folder.open) {
         File.list(folder.path, function(files) {
-          folder.children = files;
+          var childrenIds = _.map(folder.children, _.property('id'));
+          var newFiles = _.filter(files, function(file) { return !_.contains(childrenIds, file.id); });
+          folder.children = folder.children.concat(newFiles);
           if (!folder.watching) {
             folder.watching = true;
             self.$root.watch(folder.path);


### PR DESCRIPTION
Old logic: "Folder reopen cause reset of file state objects".
So I don't reset but concat new file_state_objects to folder.children. But I'm not sure that my check for 'new' is complete. I assume that the objects are the same if they have the same id.
