### PR TITLE
fix #148 auto-updating p5 libraries

### DIFF
--- a/app/modes/p5/p5-mode.js
+++ b/app/modes/p5/p5-mode.js
@@ -192,25 +192,35 @@ module.exports = {
     var fileNames = ['p5.js', 'p5.dom.js', 'p5.sound.js'];
 
     request({url: url, headers: {'User-Agent': 'request'}}, function(error, response, data){
+      if (error) return;
+
+      // filter assets to only include the filenames we want
       var assets = JSON.parse(data).assets.filter(function(asset){
         return fileNames.indexOf(asset.name) > -1;
       });
-      assets.forEach(checkAsset);
-    });
 
-    function checkAsset(asset){
-      var localPath = Path.join(libraryPath, asset.name);
-      getVersion(localPath, function(version){
-        var remoteVersion = asset.tag;
-        if (remoteVersion != version) {
-          downloadAsset(asset.browser_download_url, localPath);
+      // if remoteVersion != localVersion, download new version of each asset
+      var remoteVersion = JSON.parse(data).tag_name;
+      var localPathToP5 = Path.join(libraryPath, 'p5.js');
+
+      var localVersionTag = getVersion(localPathToP5, function(localVersion) {
+        if (remoteVersion != localVersion || !localVersion) {
+          assets.forEach(function(asset) {
+            var localPathToAsset = Path.join(libraryPath, asset.name);
+            downloadAsset(asset.browser_download_url, localPathToAsset);
+          });
         }
       });
-    }
+
+    });
 
     function downloadAsset(remote, local) {
       request({url: remote, headers: {'User-Agent': 'request'}}, function(error, response, body){
-        fs.writeFile(local, body);
+        if (error) return;
+
+        if (body.split('\n')[0].indexOf('/*! p5.') > -1) {
+          fs.writeFile(local, body);
+        }
       });
     }
   },
@@ -263,8 +273,14 @@ function getVersion(filename, callback) {
     if (err) throw err;
 
     var line = data.toString('utf-8').split("\n")[0];
-    var version = line.match(/v\d+\.\d+\.\d+/)[0].substring(1);
+    var version;
+    try {
+      version = line.match(/v\d+\.\d+\.\d+/)[0].substring(1);
+    } catch(e) {
+      version = null;
+    }
     callback(version);
+
   });
 
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,6 +169,7 @@ gulp.task('p5', function () {
       'User-Agent' : 'request'
     }
   }, function(error, response, body) {
+    if (error) return;
     var assets = JSON.parse(body).assets;
     assets.forEach(function(asset) {
       if (fileNames.indexOf(asset.name) > -1) {


### PR DESCRIPTION
- use a single tag_name for the p5.js release to determine if it's necessary to update p5.js, p5.dom.js and p5.sound.js. Individual tags for each file are no longer part of the github api.
- don't overwrite files if there is any error
- check to see that all of the files have ``/*! p5`` at the beginning before overwriting