### PR TITLE
Linux support

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -4,7 +4,7 @@ var _ = require('underscore');
 var Files = require('./files');
 
 var menubar = new gui.Menu({ type: 'menubar' });
-if (!isWin) {
+if (isMac) {
   menubar.createMacBuiltin("p5");
 }
 var fileMenu = new gui.Menu();

--- a/app/menu.js
+++ b/app/menu.js
@@ -24,7 +24,7 @@ var fs = nodeRequire('fs');
  * Menuitems may themselves be a submenu
  */
 module.exports.setup = function(app) {
-  if (isWin) {
+  if (isWin || isLinux) {
     //Setup menus for windows  
     fileMenu.append(new gui.MenuItem({ 
       label: 'New Project                          Ctrl+Shift+N',
@@ -318,7 +318,7 @@ module.exports.setup = function(app) {
     app.showHelp();
   }}));
 
-  if (isWin) {
+  if (isWin || isLinux) {
     menubar.append(new gui.MenuItem({ label: 'File', submenu: fileMenu}));
     menubar.append(new gui.MenuItem({ label: 'View', submenu: view}));
   } else {
@@ -335,7 +335,7 @@ module.exports.setup = function(app) {
   // Many of these menuItems are different because the ace/brace editor has
   // native shortcuts for these commands. Their respective menuItmes only react
   // to being clicked on, so the shortcuts work without interference.
-  if (isWin) {
+  if (isWin || isLinux) {
     var edit = new gui.Menu();
 
     var undo = new gui.MenuItem(
@@ -483,7 +483,7 @@ module.exports.setup = function(app) {
 //reset the menubar to the current window's frame of reference. Used whenever
 //the user switches focus between windows
 module.exports.resetMenu = function() {
-  if (!isWin) {
+  if (isMac) {
     // console.log(menubar);
     var serialLabel = nodeGlobal.serialrunning ? 'Stop Serial Server' : 'Start Serial Server';
     menubar.items[4].submenu.items[0].label = serialLabel;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,6 +17,7 @@ var request = require('request');
 
 var isWin = process.platform.indexOf('win') > -1;
 var isMac = process.platform.indexOf('darwin') > -1;
+var isLinux = process.platform.indexOf('linux') > -1;
 
 var builderOptions = {
   version: info.devDependencies.nw,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ var info = require('./package.json');
 var request = require('request');
 
 var isWin = process.platform.indexOf('win') > -1;
+var isMac = process.platform.indexOf('darwin') > -1;
 
 var builderOptions = {
   version: info.devDependencies.nw,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,6 +125,11 @@ function copyFfmpegBuild() {
   gulp.src('./lib/ffmpegsumo.dll')
     .pipe(gulp.dest(binaryDir + '/win64',
        {overwrite: true}));
+
+  /*console.log('copying libffmpegsumo.so to ./dist');
+  gulp.src('./lib/libffmpegsumo.so')
+    .pipe(gulp.dest(binaryDir + '/linux64',
+       {overwrite: true}));*/
 }
 
 
@@ -135,11 +140,16 @@ gulp.task('copy-ffmpeg-default', function() {
     gulp.src('./lib/ffmpegsumo.dll')
       .pipe(gulp.dest('./node_modules/nw/nwjs/',
          {overwrite: true}));
-  } else {
+  } else if (isMac) {
     gulp.src('./lib/ffmpegsumo.so')
       .pipe(gulp.dest('./node_modules/nw/nwjs/nwjs.app/Contents/Frameworks/nwjs Framework.framework/Libraries/',
          {overwrite: true}));
-    }
+  }
+  /* else if (isLinux) {
+    gulp.src('./lib/libffmpegsumo.so')
+      .pipe(gulp.dest('./node_modules/nw/nwjs/',
+         {overwrite: true}));
+  }*/
 });
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ var builderOptions = {
   buildType: 'versioned',
   files: [ './public/**'],
   buildDir: './dist',
-  platforms: ['osx64', 'win64'],
+  platforms: ['osx64', 'win64', 'linux64'],
   macIcns: './icons/p5js.icns',
   winIco: './icons/p5js.ico',
   macPlist: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,9 +15,9 @@ var fs = require('fs');
 var info = require('./package.json');
 var request = require('request');
 
-var isWin = process.platform.indexOf('win') > -1;
-var isMac = process.platform.indexOf('darwin') > -1;
-var isLinux = process.platform.indexOf('linux') > -1;
+var isWin = /^win/.test(process.platform);
+var isMac = /^darwin/.test(process.platform);
+var isLinux = /^linux/.test(process.platform);
 
 var builderOptions = {
   version: info.devDependencies.nw,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,9 +15,9 @@ var fs = require('fs');
 var info = require('./package.json');
 var request = require('request');
 
-var isWin = /^win/.test(process.platform);
-var isMac = /^darwin/.test(process.platform);
-var isLinux = /^linux/.test(process.platform);
+var isWin = process.platform === 'win32';
+var isMac = process.platform === 'darwin';
+var isLinux = process.platform === 'linux';
 
 var builderOptions = {
   version: info.devDependencies.nw,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,7 +148,15 @@ function latest () {
   console.log('Compressing...');
 
   builderOptions.platforms.forEach(function(p){
-    var output = 'p5-' + (p.indexOf('win') > -1 ? 'win' : 'mac') + '.zip';
+    // var output = 'p5-' + (p.indexOf('win') > -1 ? 'win' : 'mac') + '.zip';
+    var output = 'p5-';
+    if (p.indexOf('win') > -1) {
+      output += 'win.zip';
+    } else if (p.indexOf('osx') > -1) {
+      output += 'mac.zip';
+    } else {
+      output += 'linux.zip';
+    }
     gulp.src(binaryDir + '/' + p +'/**').
       pipe(zip(output)).
       pipe(gulp.dest(latestDir)).

--- a/public/index.html
+++ b/public/index.html
@@ -38,9 +38,9 @@
       var gui = window.require('nw.gui');
 
       //platform
-      var isWin = /^win/.test(process.platform);
-      var isMac = /^darwin/.test(process.platform);
-      var isLinux = /^linux/.test(process.platform);
+      var isWin = process.platform === 'win32';
+      var isMac = process.platform === 'darwin';
+      var isLinux = process.platform === 'linux';
 
       //preserve node keywords
       var nodeRequire = require;

--- a/public/index.html
+++ b/public/index.html
@@ -39,6 +39,8 @@
 
       //platform
       var isWin = /^win/.test(process.platform);
+      var isMac = /^darwin/.test(process.platform);
+      var isLinux = /^linux/.test(process.platform);
 
       //preserve node keywords
       var nodeRequire = require;


### PR DESCRIPTION
Adds support for running and building for Linux 64bit.

Note that boilerplate comments are set up in the gulpfile to copy a custom build ffmpeg library for Linux into the dist, however, I don't have this at the moment so sound doesn't work. Making it work would be a matter of getting the custom libffmpegsumo.so library built for Linux 64bit with the relevant codec support, putting it in ./lib and uncommenting the code in gulpfile for copying the linux library.