### PR TITLE
Support styling and multiple arguments in console.* methods

### DIFF
--- a/public/js/debug-console.js
+++ b/public/js/debug-console.js
@@ -7,11 +7,14 @@
   ["log", "warn", "error"].forEach(function(func) {
     window.console[func] = function(msg) {
       var style = null;
-      if (arguments[2] && arguments[0].indexOf('%c') > -1) {
+      var messages = Array.prototype.slice.call(arguments);
+      if (arguments[0].indexOf('%c') > -1 && arguments.length > 1) {
         style = arguments[1];
+        messages.splice(1, 1); // remove style string from console output
       }
+
       var data = {
-        msg: JSON.stringify(JSON.decycle(msg, true), null, '  '),
+        msg: messages.map(toMessage).join(' '),
         style: style,
         type: func
       };
@@ -35,6 +38,10 @@
 
     return false;
   };
+
+  function toMessage (msg) {
+    return JSON.stringify(JSON.decycle(msg, true), null, '  ');
+  }
 
   function downloadFile() {
     window.opener.postMessage(JSON.stringify({ downloadFile: arguments }), 'file://');


### PR DESCRIPTION
Hello! Nice tool. :smile: 

I'm not familiar with Processing so forgive me if this was an intentional decision made for some legacy reason. But I've noticed `console.log(2, 4, 2)` only prints the first argument, which is non-standard in the rest of the JS world. I've also noticed that `console.log('%cHello', 'background: red')` does not style, since it is looking for a third argument.

This PR changes it so that users can pass multiple arguments to `console.log` and they will all appear in the debug console. It also improves the styling a bit so it works a little more reliably.

Examples:
```js
console.log(width, height);
//=> 50 150

console.log('%chello', 'background: red');
//=> "hello" (in red)

console.log('%chello', 'background: red', 2);
//=> "hello" 2 (in red)
```