### PR TITLE
Small change to ensure styling is only applied to logs with strings

### DIFF
--- a/public/js/debug-console.js
+++ b/public/js/debug-console.js
@@ -8,7 +8,12 @@
     window.console[func] = function(msg) {
       var style = null;
       var messages = Array.prototype.slice.call(arguments);
-      if (arguments[0].indexOf('%c') > -1 && arguments.length > 1) {
+
+      // e.g. console.log('%cHello', 'background: red', 'foobar');
+      if (arguments.length > 1 &&
+          typeof arguments[0] === 'string' &&
+          typeof arguments[1] === 'string' &&
+          arguments[0].indexOf('%c') > -1) {
         style = arguments[1];
         messages.splice(1, 1); // remove style string from console output
       }


### PR DESCRIPTION
After my last PR, https://github.com/processing/p5.js-editor/pull/244, there is a slight bug when you do something like this (passing numbers or non-strings) –

```js
console.log(mouseX, mouseY);
```

This PR should fix that to ensure that styling is only applied when the first two arguments are strings, like this:

```js
console.log('%cMouse:', 'background: red', mouseX, mouseY);
```